### PR TITLE
feat: allow the registered spawn fn to access and alter tags

### DIFF
--- a/crates/bevy_hui/src/build.rs
+++ b/crates/bevy_hui/src/build.rs
@@ -568,7 +568,9 @@ impl<'w, 's> TemplateBuilder<'w, 's> {
 
         // ----------------------
         //tags
-        self.cmd.entity(entity).insert(Tags(tags));
+        if tags.len() > 0 {
+            self.cmd.entity(entity).insert(Tags(tags));
+        }
 
         for child in node.children.iter() {
             let child_entity = self.cmd.spawn_empty().id();

--- a/crates/bevy_hui/src/build.rs
+++ b/crates/bevy_hui/src/build.rs
@@ -418,10 +418,6 @@ impl<'w, 's> TemplateBuilder<'w, 's> {
         }
 
         // ----------------------
-        //tags
-        self.cmd.entity(entity).insert(Tags(node.tags.clone()));
-
-        // ----------------------
         // connections
         if let Some(id) = &node.id {
             self.ids.insert(id.clone(), entity);
@@ -452,6 +448,8 @@ impl<'w, 's> TemplateBuilder<'w, 's> {
         if let Some(outline) = styles.computed.outline.as_ref() {
             self.cmd.entity(entity).insert(outline.clone());
         }
+
+        let mut tags = node.tags.clone();
 
         match &node.node_type {
             // --------------------------------
@@ -530,7 +528,7 @@ impl<'w, 's> TemplateBuilder<'w, 's> {
             }
             NodeType::Custom(custom) => {
                 // mark children
-                self.comps.try_spawn(custom, entity, &mut self.cmd);
+                self.comps.try_spawn(custom, entity, &mut self.cmd, &mut tags);
                 if node.children.len() > 0 {
                     let slot_holder = self.cmd.spawn(Node::default()).id();
                     for child_node in node.children.iter() {
@@ -567,6 +565,10 @@ impl<'w, 's> TemplateBuilder<'w, 's> {
                 return;
             }
         };
+
+        // ----------------------
+        //tags
+        self.cmd.entity(entity).insert(Tags(tags));
 
         for child in node.children.iter() {
             let child_entity = self.cmd.spawn_empty().id();

--- a/example/src/ui.rs
+++ b/example/src/ui.rs
@@ -74,7 +74,7 @@ fn setup(
     );
 
     // register custom node by passing a template handle
-    html_comps.register_with_spawn_fn("panel", server.load("demo/panel.html"), |mut cmd| {
+    html_comps.register_with_spawn_fn("panel", server.load("demo/panel.html"), |mut cmd, _| {
         cmd.insert(Name::new("Panel"));
     });
 


### PR DESCRIPTION
I was playing with the `register_with_spawn_fn` and wanted to access some of the tags on the custom component during that function.  For instance, I was making a `radio_select` and was using the spawn function to tack on a `RadioSelect(u8)` component and I wanted to have the default selected `radio_option` index as my value.  To do that I was utilizing the `Tags` functionality, but realized I couldn't access `Tags` in the spawn function.

I updated the bindings to send in a mutable reference clone of tags that could be parsed and manipulated as part of the spawn function.  Then when going through the build process I moved the tag component insertion down so that if tags was altered by the spawn function (i.e. removing tags that have been processed into components), it would reflect that in the `Tags` component.

This modification is breaking previous versions that utilize `register_with_spawn_fn` unfortunately, but it's an easy adaptation of just adding `, _` to your signature if you don't care about the tags.

I also made it so that the Tags component is only added if there are tags to supplied.  This should help `Query` asking for entities with `Tags` not pull in things it doesn't need to.