### PR TITLE
feat: bevy_picking support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,7 @@ name = "bevy_hui"
 version = "0.4.0"
 dependencies = [
  "bevy",
+ "bevy_picking",
  "nom",
  "owo-colors",
  "test-case",

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ https://github.com/user-attachments/assets/4eb22305-7762-404e-9093-806b6a155ede
   in your templates `on_press="start_game"`.
 - No widgets, no themes. Just bevy UI serialized with all the tools necessary to build anything
   in a reusable manor.
+- Optional `bevy_picking` support: `picking`
+```
+features = ["picking"]
+```
 
 ## Compatibility
 

--- a/crates/bevy_hui/Cargo.toml
+++ b/crates/bevy_hui/Cargo.toml
@@ -25,11 +25,13 @@ bevy = { version = "0.16", default-features = false, features = [
   "bevy_text",
   "bevy_log",
 ] }
+bevy_picking = { version = "0.16", optional = true }
 thiserror = "1.0.63"
 nom = "7.1.3"
 owo-colors = "4.1.0"
 
 [features]
+picking = ["dep:bevy_picking"]
 default = []
 
 [dev-dependencies]

--- a/crates/bevy_hui/src/build.rs
+++ b/crates/bevy_hui/src/build.rs
@@ -488,6 +488,13 @@ impl<'w, 's> TemplateBuilder<'w, 's> {
         if let Some(outline) = styles.computed.outline.as_ref() {
             self.cmd.entity(entity).insert(outline.clone());
         }
+        
+        // ----------------------
+        // pickable
+        #[cfg(feature = "picking")]
+        if let Some(pickable) = styles.computed.pickable.as_ref() {
+            self.cmd.entity(entity).insert(pickable.clone());
+        }
 
         match &node.node_type {
             // --------------------------------

--- a/crates/bevy_hui/src/data.rs
+++ b/crates/bevy_hui/src/data.rs
@@ -230,6 +230,11 @@ pub enum StyleAttr {
     ImageColor(Color),
     ImageScaleMode(NodeImageMode),
     ImageRegion(Rect),
+
+    // -----
+    // picking
+    #[cfg(feature = "picking")]
+    Pickable((bool, bool)),
 }
 
 impl Default for StyleAttr {

--- a/crates/bevy_hui/src/parse.rs
+++ b/crates/bevy_hui/src/parse.rs
@@ -476,6 +476,9 @@ where
         b"fps" => map(parse_number, StyleAttr::FPS)(value)?,
         b"frames" => map(parse_number_vec, StyleAttr::Frames)(value)?,
 
+        #[cfg(feature = "picking")]
+        b"pickable" => map(parse_pickable, |v| StyleAttr::Pickable(v))(value)?,
+
         _ => {
             let err = E::from_error_kind(
                 ident,
@@ -1501,6 +1504,21 @@ where
             map(terminated(parse_float, tag("s")), |v| v),
             map(terminated(parse_float, tag("ms")), |v| v / 1000.),
             map(parse_float, |v| v),
+        )),
+    )(input)
+}
+
+#[cfg(feature = "picking")]
+fn parse_pickable<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], (bool, bool), E>
+where
+    E: ParseError<&'a [u8]> + ContextError<&'a [u8]>,
+{
+    context(
+        "is not valid pickable `should_block_lower: bool is_hoverable: bool`.
+                 Try `true false` to make blocking inactive object or `false true` to make object picking-transparent",
+        tuple((
+            preceded(multispace0, parse_bool),
+            preceded(multispace0, parse_bool),
         )),
     )(input)
 }

--- a/crates/bevy_hui/src/styles.rs
+++ b/crates/bevy_hui/src/styles.rs
@@ -449,6 +449,8 @@ pub struct ComputedStyle {
     pub easing: Option<EaseFunction>,
     pub zindex: Option<ZIndex>,
     pub global_zindex: Option<GlobalZIndex>,
+    #[cfg(feature = "picking")]
+    pub pickable: Option<Pickable>,
 }
 
 impl Default for ComputedStyle {
@@ -477,6 +479,8 @@ impl Default for ComputedStyle {
             easing: Some(EaseFunction::Linear),
             zindex: None,
             global_zindex: None,
+            #[cfg(feature = "picking")]
+            pickable: None
         }
     }
 }
@@ -662,6 +666,13 @@ impl HtmlStyle {
                     ));
                 }
             },
+            #[cfg(feature = "picking")]
+            StyleAttr::Pickable((should_block_lower, is_hoverable)) => {
+                self.computed.pickable = Some(Pickable {
+                    should_block_lower,
+                    is_hoverable,
+                })
+            }
             // StyleAttr::Font(font) => self.regular.font = server
             _ => (),
         };

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -58,7 +58,7 @@
 | shadow_blur           | ref `Val`                                                                                                |
 | shadow_spread         | ref `Val`                                                                                                |
 | shadow_offset         | ref `Val` `Val` shadow_offset="10px 10px"                                                                |
-| text_shadow           | `(2,1) #000` ref `Vec2 Color`                                                                   |
+| text_shadow           | `(2,1) #000` ref `Vec2 Color`                                                                            |
 | font                  | asset path                                                                                               |
 | font_color            | ref `Color`                                                                                              |
 | font_size             | float                                                                                                    |
@@ -91,7 +91,9 @@
 | aspect_ratio          | float                                                                                                    |
 | zindex                | int                                                                                                      |
 | global_zindex         | int                                                                                                      |
-| aspect_ratio          | float                                                                                                    |
+| pickable*             | bool, bool (should_block_lower, is_hoverable)                                                            |
+
+Enabled by `picking` feature
 
 ## Conditional Styles
 


### PR DESCRIPTION
This pull request adds `bevy_picking` support with `pickable="bool bool"` style attribute

Every `picking` feature addition have `#[cfg(feature = "picking")]`

Use case: allow nodes to be picking-transparent for scroll behavior