### PR TITLE
change the documentation of flex_direction attribute to match actual allowed values

### DIFF
--- a/crates/bevy_hui/src/parse.rs
+++ b/crates/bevy_hui/src/parse.rs
@@ -769,7 +769,7 @@ where
     E: ParseError<&'a [u8]> + ContextError<&'a [u8]>,
 {
     context(
-        "flex_direction has no valid value. Try `auto` `center` `start` `stretch` `end` `baseline`",
+        "flex_direction has no valid value. Try `row` `column` `column_reverse` `row_reverse` `default`",
         alt((
             map(tag("row"), |_| FlexDirection::Row),
             map(tag("column"), |_| FlexDirection::Column),

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -37,7 +37,7 @@
 | justify_self          | `auto` `center` `start` `stretch` `end` `baseline`                                                       |
 | justify_items         | `default` `center` `start` `end` `baseline`                                                              |
 | justify_content       | `center` `start` `flex_start` `stretch` `end` `space_evenly` `space_around` `space_between` `flex_start` |
-| flex_direction        | `auto` `center` `start` `stretch` `end` `baseline`                                                       |
+| flex_direction        | `row` `column` `column_reverse` `row_reverse` `default` `baseline`                                                       |
 | flex_wrap             | `wrap` `no_wrap` `wrap_reverse`                                                                          |
 | flex_grow             | float                                                                                                    |
 | flex_shrink           | float                                                                                                    |


### PR DESCRIPTION
The documentation and html parser incorrectly marks the allowed values of `flex_direction` as `auto`, `center`, `start`, `stretch`, `end` and `baseline` as opposed to the actual allowed values: `row`, `column`, `column_reverse`, `row_reverse` and `default`