### PR TITLE
fix for flash of unstyled content

### DIFF
--- a/crates/bevy_hui/src/build.rs
+++ b/crates/bevy_hui/src/build.rs
@@ -13,7 +13,12 @@ use std::time::Duration;
 pub struct BuildPlugin;
 impl Plugin for BuildPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, (hotreload, spawn_ui, move_children_to_slot).chain())
+        app.add_systems(
+            Update,
+            (hotreload, spawn_ui, move_children_to_slot)
+                .chain()
+                .in_set(crate::HuiSystems::Build),
+        )
             .register_type::<TemplatePropertySubscriber>()
             .register_type::<TemplateExpresions>()
             .register_type::<TemplateProperties>()

--- a/crates/bevy_hui/src/lib.rs
+++ b/crates/bevy_hui/src/lib.rs
@@ -3,6 +3,7 @@
 #![doc = include_str!("../../../README.md")]
 
 use bevy::app::{App, Plugin, Update};
+use bevy::ecs::schedule::{ApplyDeferred, IntoScheduleConfigs, SystemSet};
 use animation::run_animations;
 
 mod animation;
@@ -17,6 +18,12 @@ mod parse;
 mod styles;
 mod util;
 mod adaptor;
+
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum HuiSystems {
+    Build,
+    Style,
+}
 
 pub mod prelude {
     pub use crate::auto::{AutoLoadState, HuiAutoLoadPlugin};
@@ -45,6 +52,14 @@ impl Plugin for HuiPlugin {
             bindings::BindingPlugin,
             styles::TransitionPlugin,
             compile::CompilePlugin,
-        )).add_systems(Update, run_animations);
+        ))
+        .configure_sets(Update, HuiSystems::Build.before(HuiSystems::Style))
+        .add_systems(
+            Update,
+            ApplyDeferred
+                .after(HuiSystems::Build)
+                .before(HuiSystems::Style),
+        )
+        .add_systems(Update, run_animations);
     }
 }

--- a/crates/bevy_hui/src/styles.rs
+++ b/crates/bevy_hui/src/styles.rs
@@ -15,7 +15,10 @@ use std::time::Duration;
 pub struct TransitionPlugin;
 impl Plugin for TransitionPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, (continues_interaction_checking, update_node_style));
+        app.add_systems(
+            Update,
+            (continues_interaction_checking, update_node_style).in_set(crate::HuiSystems::Style),
+        );
         app.register_type::<PressedTimer>();
         app.register_type::<HoverTimer>();
         app.register_type::<InteractionTimer>();


### PR DESCRIPTION
There's an issue in that newly built nodes can wait a frrame to get styled properly. This made the crate borderline unusable for me since it caused stuff to jump around a lot when dynamically adding elements. Fortunately was a quick fix, so thought I'd make a pull request for it.

AI disclosure: I just let claude have at it for this one. I did review the code though, not hard to when it was so little.