### PR TITLE
expose AssetLoadAdaptor trait

### DIFF
--- a/crates/bevy_hui/src/lib.rs
+++ b/crates/bevy_hui/src/lib.rs
@@ -41,7 +41,7 @@ pub mod prelude {
     pub use crate::parse::parse_template;
     pub use crate::styles::{HoverTimer, HtmlStyle, InteractionTimer, PressedTimer, UiActive};
     pub use crate::HuiPlugin;
-    pub use crate::adaptor::AssetServerAdaptor;
+    pub use crate::adaptor::{AssetServerAdaptor, AssetLoadAdaptor};
 }
 pub struct HuiPlugin;
 impl Plugin for HuiPlugin {


### PR DESCRIPTION
In contexts where a custom asset loader is used, the AssetLoadAdaptor trait can sometimes be necessary to use for example a different asset source.